### PR TITLE
Format Eventbrite dates with Polylang

### DIFF
--- a/wp-content/themes/pawar2018/archive-events.php
+++ b/wp-content/themes/pawar2018/archive-events.php
@@ -36,7 +36,7 @@
 
                   <p class="event-date">
                     <?php
-                    echo date_format($date, 'l, F d \a\t h:i a');
+                    echo date_i18n( 'l, F d \a\t h:i a', strtotime(eventbrite_event_start()->local) );
                     ?>
                   </p>
 

--- a/wp-content/themes/pawar2018/archive-events.php
+++ b/wp-content/themes/pawar2018/archive-events.php
@@ -36,7 +36,7 @@
 
                   <p class="event-date">
                     <?php
-                    echo date_i18n( 'l, F d \a\t h:i a', strtotime(eventbrite_event_start()->local) );
+                    echo date_i18n( pll__('l, F d \a\t h:i a'), strtotime(eventbrite_event_start()->local) );
                     ?>
                   </p>
 

--- a/wp-content/themes/pawar2018/footer.php
+++ b/wp-content/themes/pawar2018/footer.php
@@ -36,14 +36,14 @@
 		</div>
 		<div class="small-11 medium-5 large-4 columns">
 			<div class="footer-signup">
-				<h6 class="section-title">Newsletter</h6>
-				<h3 class="footer-newsletter">Stay in the loop.</h3>
-				<a href="/newsletter" class="button">Subscribe</a>
+				<h6 class="section-title"><?php pll_e('Newsletter'); ?></h6>
+				<h3 class="footer-newsletter"><?php pll_e('Stay in the loop.'); ?></h3>
+				<a href="<?php pll_e('/newsletter') ?>" class="button"><?php pll_e('Subscribe'); ?></a>
 			</div>
 		</div>
 		<div class="small-11 medium-4 large-4 columns">
 			<div class="footer-info">
-				<h6 class="section-title">Ameya Pawar For Governor</h6>
+				<h6 class="section-title"><?php pll_e('Ameya Pawar for Governor'); ?></h6>
 				<a class="footer__link" href="mailto:info@pawar2018.com">info@pawar2018.com</a>
 				<p>P.O. Box 577162<br>Chicago, Il 60657</p>
 		</div>

--- a/wp-content/themes/pawar2018/front-page.php
+++ b/wp-content/themes/pawar2018/front-page.php
@@ -104,7 +104,7 @@ get_header(); ?>
                     <a href="<?= eventbrite_event_eb_url(); ?>">
                       <p class="event-date">
                         <?php
-                        echo date_format(date_create(eventbrite_event_start()->local), 'l, F d \a\t h:i a');
+                        echo date_i18n( 'l, F d \a\t h:i a', strtotime(eventbrite_event_start()->local) );
                         ?>
                       </p>
                       <h5 class="event-title">

--- a/wp-content/themes/pawar2018/front-page.php
+++ b/wp-content/themes/pawar2018/front-page.php
@@ -134,7 +134,7 @@ get_header(); ?>
           </div>
           <div class="column event-copy">
             <a href="<?php echo esc_url( home_url( '/events' )) ?>" class="button">
-              See All Events
+              <?php echo get_field('event_button') ?>
             </a>
           </div>
         </div>

--- a/wp-content/themes/pawar2018/front-page.php
+++ b/wp-content/themes/pawar2018/front-page.php
@@ -104,7 +104,7 @@ get_header(); ?>
                     <a href="<?= eventbrite_event_eb_url(); ?>">
                       <p class="event-date">
                         <?php
-                        echo date_i18n( 'l, F d \a\t h:i a', strtotime(eventbrite_event_start()->local) );
+                        echo date_i18n( pll__('l, F d \a\t h:i a'), strtotime(eventbrite_event_start()->local) );
                         ?>
                       </p>
                       <h5 class="event-title">

--- a/wp-content/themes/pawar2018/functions.php
+++ b/wp-content/themes/pawar2018/functions.php
@@ -70,7 +70,13 @@ function _pawar2018_setup() {
 	add_theme_support( 'customize-selective-refresh-widgets' );
 
 	// Register string to be translated in admin UI
-	pll_register_string( 'Eventbrite date format', 'l, F d \a\t h:i a'); 
+	pll_register_string( 'Eventbrite date format', 'l, F d \a\t h:i a');
+	pll_register_string( 'Signup title', 'Newsletter', 'Footer');
+	pll_register_string( 'Signup text', 'Stay in the loop.', 'Footer');
+	pll_register_string( 'Signup button', 'Subscribe', 'Footer');
+	pll_register_string( 'Signup URL', '/newsletter', 'Footer');
+	pll_register_string( 'Organization', 'Ameya Pawar for Governor', 'Footer');
+	pll_register_string( 'Disclaimer', 'Paid For By Ameya Pawar For Governor.', 'Footer');
 }
 endif;
 add_action( 'after_setup_theme', '_pawar2018_setup' );

--- a/wp-content/themes/pawar2018/functions.php
+++ b/wp-content/themes/pawar2018/functions.php
@@ -42,7 +42,6 @@ function _pawar2018_setup() {
 	 */
 	add_theme_support( 'post-thumbnails' );
 
-	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
 	    'header-menu'   => __( 'Header Menu' ),
 	    'footer-menu'   => __( 'Footer Menu' ),
@@ -69,6 +68,9 @@ function _pawar2018_setup() {
 
 	// Add theme support for selective refresh for widgets.
 	add_theme_support( 'customize-selective-refresh-widgets' );
+
+	// Register string to be translated in admin UI
+	pll_register_string( 'Eventbrite date format', 'l, F d \a\t h:i a'); 
 }
 endif;
 add_action( 'after_setup_theme', '_pawar2018_setup' );

--- a/wp-content/themes/pawar2018/template-parts/footer-paid.php
+++ b/wp-content/themes/pawar2018/template-parts/footer-paid.php
@@ -1,5 +1,5 @@
 <div class="footer-paid">
 	<div class="row align-center">
-		<p class="column">Paid For By Ameya Pawar For Governor.</p>
+		<p class="column"><?php pll_e('Paid For By Ameya Pawar For Governor.'); ?></p>
 	</div>
 </div>


### PR DESCRIPTION
# What does this pull request do?
- Formats Eventbrite dates with Polylang
- Converts footer fields and event CTA to custom fields or Polylang translated strings

# How should the reviewer test this pull request?
- In Languages > String translations, find the Eventbrite date format string (might be on a second page)
- Update the version for Spanish to something like 'l, d \d\e F H:i' (e.g., "Miercoles, 07 de Junio 21:00")
- Save changes
- Load the site on staging in the Spanish locale (http://ameyapawar2018.staging.wpengine.com/es) once Polylang is enabled and this code is active there

I tested this locally by assuming the output of `eventbrite_event_start()->local` is something parseable by PHP date functions, which it seems to be from the existing code.

# Any another context you want to provide?
🗓 🗺  🇲🇽  